### PR TITLE
Add performance benchmark build flag

### DIFF
--- a/Game/Core/GameRunner.h
+++ b/Game/Core/GameRunner.h
@@ -15,7 +15,6 @@
 #include <QWheelEvent>
 #include <algorithm>
 
-#define PERFORMANCE_BENCHMARK
 
 namespace Game {
 namespace Core {

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ make
 
 The built binary will be placed in the current directory.
 
-To enable the optional performance benchmark mode, define `PERFORMANCE_BENCHMARK` before building. This can be done by uncommenting the macro in `Game/Core/GameRunnerView.h` (and `Game/Core/GameRunner.h`) or by passing `DEFINES+=PERFORMANCE_BENCHMARK` to `qmake`.
+To enable the optional performance benchmark mode, build using the
+`performance_benchmark` configuration:
+
+```bash
+qmake CONFIG+=performance_benchmark SpaceInvaders.pro
+make
+```
 
 ## Gameplay
 

--- a/SpaceInvaders.pro
+++ b/SpaceInvaders.pro
@@ -8,6 +8,11 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 CONFIG += c++17
 
+# Optional performance benchmark build
+performance_benchmark {
+    DEFINES += PERFORMANCE_BENCHMARK
+}
+
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0


### PR DESCRIPTION
## Summary
- remove obsolete macro define from `GameRunner.h`
- add optional `performance_benchmark` config in qmake project file
- document how to enable benchmarking in README

## Testing
- `qmake -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586a9650588323ad137b8893717c45