### PR TITLE
Add cross-platform setup scripts

### DIFF
--- a/scripts/setup_and_build_linux.sh
+++ b/scripts/setup_and_build_linux.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+# Install dependencies for Ubuntu/Debian
+sudo apt update
+sudo apt install -y build-essential qtbase5-dev qt5-qmake libopenal-dev libsndfile1-dev libyaml-cpp-dev
+
+# Build Space Invaders
+qmake SpaceInvaders.pro
+make -j$(nproc)

--- a/scripts/setup_and_build_macos.sh
+++ b/scripts/setup_and_build_macos.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+# Install dependencies using Homebrew
+brew install qt openal-soft libsndfile yaml-cpp
+# Ensure qmake is on PATH
+export PATH="$(brew --prefix qt)/bin:$PATH"
+
+# Build Space Invaders
+qmake SpaceInvaders.pro
+make -j$(sysctl -n hw.ncpu)

--- a/scripts/setup_and_build_windows.bat
+++ b/scripts/setup_and_build_windows.bat
@@ -1,0 +1,21 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+rem Install OpenAL runtime
+if exist "Thirdparty\OpenAL\redist\oalinst.exe" (
+    "Thirdparty\OpenAL\redist\oalinst.exe" /S
+)
+
+rem Build yaml-cpp
+cd Thirdparty\yaml-cpp
+if not exist build mkdir build
+cd build
+cmake .. -A x64
+cmake --build . --config Release
+cd ..\..\..
+
+rem Build Space Invaders
+qmake SpaceInvaders.pro
+make
+
+endlocal


### PR DESCRIPTION
## Summary
- add scripts to install dependencies and build for Linux
- add scripts for macOS and Windows

## Testing
- `nl -ba scripts/setup_and_build_linux.sh`
- `nl -ba scripts/setup_and_build_macos.sh`
- `nl -ba scripts/setup_and_build_windows.bat`


------
https://chatgpt.com/codex/tasks/task_e_68587ea787508323a8e6af098ecd1a67