### PR TITLE
Fix BVH collision detection

### DIFF
--- a/Game/CollisionDetection/BVHTree.cpp
+++ b/Game/CollisionDetection/BVHTree.cpp
@@ -80,17 +80,15 @@ BVHTree::query(std::shared_ptr<BVHNode> node,
               : std::make_pair(node->objects[i]->id(), queryObject->id());
 
       if (m_processedPairs.find(sortedPair) == m_processedPairs.end()) {
-
-        if (queryObject->isCollidable() && node->objects[i]->isCollidable()) {
-          if (canCollide(queryObject->objectTypes(),
-                         node->objects[i]->objectTypes())) {
-            if (node->objects[i]->getBoundingBox().intersects(
-                    queryObject->getBoundingBox())) {
-              result.push_back(node->objects[i]);
-            }
+        if (queryObject->isCollidable() && node->objects[i]->isCollidable() &&
+            canCollide(queryObject->objectTypes(),
+                       node->objects[i]->objectTypes())) {
+          if (node->objects[i]->getBoundingBox().intersects(
+                  queryObject->getBoundingBox())) {
+            result.push_back(node->objects[i]);
           }
+          m_processedPairs.insert(sortedPair);
         }
-        m_processedPairs.insert(sortedPair);
       }
     }
     return result;


### PR DESCRIPTION
## Summary
- avoid marking uncollidable BVH pairs as processed

## Testing
- `bash scripts/setup_and_build_linux.sh` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_6859c2040cdc8323bf294df824a203dc