### PR TITLE
Improve const correctness

### DIFF
--- a/GameObjects/Collectables/Collectable.cpp
+++ b/GameObjects/Collectables/Collectable.cpp
@@ -19,7 +19,7 @@ void GameObjects::Collectables::Collectable::update(
   }
 }
 
-bool Collectable::shouldBeDeleted() {
+bool Collectable::shouldBeDeleted() const {
   return GameObject::shouldBeDeleted() || m_collected || m_lifeSpanExceeded;
 }
 

--- a/GameObjects/Collectables/Collectable.h
+++ b/GameObjects/Collectables/Collectable.h
@@ -25,7 +25,7 @@ public:
 
   void update(const UpdateContext &context) override;
 
-  bool shouldBeDeleted() override;
+  bool shouldBeDeleted() const override;
   void collideWithPlayerShip(Ships::PlayerShip &playerShip) override;
 
 private:

--- a/GameObjects/GameObject.cpp
+++ b/GameObjects/GameObject.cpp
@@ -25,7 +25,7 @@ void GameObject::initialize() {
   initializeDestructionEffects();
 }
 
-bool GameObject::shouldBeDeleted() {
+bool GameObject::shouldBeDeleted() const {
   return m_position.isBeyondLimits(25, 25, 50, 30);
 }
 
@@ -154,7 +154,7 @@ void GameObject::addMovementStrategy(
   m_movementStrategy = m_movementStrategy + newMovementStrategy;
 }
 
-std::uint64_t GameObject::id() { return m_id; }
+std::uint64_t GameObject::id() const { return m_id; }
 
 const Magnetism &GameObject::magnetism() const { return m_magnetism; }
 

--- a/GameObjects/GameObject.h
+++ b/GameObjects/GameObject.h
@@ -77,7 +77,7 @@ public:
 
   // Initialization & Lifecycle
   virtual void initialize();
-  virtual bool shouldBeDeleted();
+  virtual bool shouldBeDeleted() const;
 
   // Collision Handlers
   virtual void collideWith(GameObject &other) { Q_UNUSED(other); }
@@ -108,7 +108,7 @@ public:
   QString getHudPixmapPath() const;
   void setPosition(const Position &newPosition);
   bool isCollidable() const;
-  std::uint64_t id();
+  std::uint64_t id() const;
   const Magnetism &magnetism() const;
 
   // Actions & Modifiers

--- a/GameObjects/Projectiles/Projectile.cpp
+++ b/GameObjects/Projectiles/Projectile.cpp
@@ -20,7 +20,7 @@ std::unique_ptr<GameObject> Projectile::clone() const {
   return projectile;
 }
 
-bool Projectile::shouldBeDeleted() {
+bool Projectile::shouldBeDeleted() const {
   bool isPiercing =
       m_properties.find(ProjectileProperty::PIERCING) != m_properties.end();
 

--- a/GameObjects/Projectiles/Projectile.h
+++ b/GameObjects/Projectiles/Projectile.h
@@ -20,7 +20,7 @@ public:
   virtual ~Projectile() = default;
   virtual std::unique_ptr<GameObject> clone() const override;
 
-  bool shouldBeDeleted() override;
+  bool shouldBeDeleted() const override;
   void collideWith(GameObject &other) override;
   void collideWithEnemyShip(Ships::EnemyShip &enemyShip) override;
   void collideWithPlayerShip(Ships::PlayerShip &playerShip) override;

--- a/GameObjects/Projectiles/Vortex.cpp
+++ b/GameObjects/Projectiles/Vortex.cpp
@@ -27,7 +27,7 @@ void Vortex::collideWithEnemyShip(Ships::EnemyShip &enemyShip) {
   disableMovement();
 }
 
-bool Vortex::shouldBeDeleted() {
+bool Vortex::shouldBeDeleted() const {
   return GameObject::shouldBeDeleted() ||
          m_timeSinceSpawnSeconds >= m_timeToLiveSeconds;
 }

--- a/GameObjects/Projectiles/Vortex.h
+++ b/GameObjects/Projectiles/Vortex.h
@@ -17,7 +17,7 @@ private:
 public:
   void update(const UpdateContext &context) override;
   void collideWithEnemyShip(Ships::EnemyShip &enemyShip) override;
-  bool shouldBeDeleted() override;
+  bool shouldBeDeleted() const override;
   std::unique_ptr<GameObject> clone() const override;
 };
 

--- a/GameObjects/Projectiles/WaveOfDestruction.cpp
+++ b/GameObjects/Projectiles/WaveOfDestruction.cpp
@@ -11,7 +11,7 @@ WaveOfDestruction::WaveOfDestruction() {
   m_pixmapData.keepAspectRatio = false;
 }
 
-bool WaveOfDestruction::shouldBeDeleted() {
+bool WaveOfDestruction::shouldBeDeleted() const {
   return m_position.isBeyondScreenBottomLimit(50) ||
          m_position.isBeyondScreenTopLimit(50);
 }

--- a/GameObjects/Projectiles/WaveOfDestruction.h
+++ b/GameObjects/Projectiles/WaveOfDestruction.h
@@ -12,7 +12,7 @@ public:
 
   // GameObject interface
 public:
-  bool shouldBeDeleted() override;
+  bool shouldBeDeleted() const override;
 
   // Projectile interface
 public:

--- a/GameObjects/Ships/EnemyShip.cpp
+++ b/GameObjects/Ships/EnemyShip.cpp
@@ -113,7 +113,7 @@ std::unique_ptr<GameObject> EnemyShip::clone() const {
   return enemyShip;
 }
 
-bool EnemyShip::shouldBeDeleted() {
+bool EnemyShip::shouldBeDeleted() const {
   if (m_position.isBeyondScreenBottomLimit() && !m_bottomEdgeSignalEmitted) {
     emit bottomEdgeReached();
     m_bottomEdgeSignalEmitted = true;

--- a/GameObjects/Ships/EnemyShip.h
+++ b/GameObjects/Ships/EnemyShip.h
@@ -32,13 +32,13 @@ protected:
   void initializeSounds() override;
 
 private:
-  bool m_bottomEdgeSignalEmitted;
+  mutable bool m_bottomEdgeSignalEmitted;
   void clampHealthSpawnProbability();
 
   // GameObject interface
 public:
   std::unique_ptr<GameObject> clone() const override;
-  bool shouldBeDeleted() override;
+  bool shouldBeDeleted() const override;
 
 signals:
   void enemyShipDeleted();

--- a/GameObjects/Ships/Ship.cpp
+++ b/GameObjects/Ships/Ship.cpp
@@ -159,7 +159,7 @@ void Ship::setMaxEnergy(float newMaxEnergy) { m_maxEnergy = newMaxEnergy; }
 
 int Ship::currentHp() const { return m_currentHealth; }
 
-bool Ship::shouldBeDeleted() {
+bool Ship::shouldBeDeleted() const {
   return GameObject::shouldBeDeleted() ||
          (isDead() && m_destructionAnimation.animationFinished() &&
           m_destructionEffect.effectFinished());

--- a/GameObjects/Ships/Ship.h
+++ b/GameObjects/Ships/Ship.h
@@ -19,7 +19,7 @@ public:
   Ship(const std::uint32_t maxHp, const float speed, const Position &position);
   virtual ~Ship();
   virtual void update(const UpdateContext &context) override;
-  virtual bool shouldBeDeleted() override;
+  virtual bool shouldBeDeleted() const override;
   bool isDead() override;
   virtual void takeDamage(std::uint32_t amount);
   virtual void heal(std::uint32_t amount);


### PR DESCRIPTION
## Summary
- mark various `shouldBeDeleted` methods as `const`
- mark `GameObject::id` as `const`
- update derived classes and headers accordingly
- use `mutable` for `EnemyShip` flag that changes in a const method

## Testing
- `./scripts/setup_and_build_linux.sh` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_6859e869993c8323a2b36eb8fbd5d83c