### PR TITLE
Preload pixmaps for game objects

### DIFF
--- a/GameObjects/Collectables/Health.cpp
+++ b/GameObjects/Collectables/Health.cpp
@@ -1,4 +1,6 @@
 #include "Health.h"
+#include "Graphics/PixmapLibrary.h"
+#include "Graphics/PixmapRegistry.h"
 
 namespace GameObjects {
 namespace Collectables {
@@ -6,6 +8,10 @@ namespace Collectables {
 Health::Health(const Position &position) : Collectable(position) {
   m_pixmapData.pixmapResourcePath = ":/Images/health.png";
   m_pixmapData.pixmapScale = QPointF(22.0, 22.0);
+}
+
+void Health::registerPixmaps() {
+    Graphics::PixmapLibrary::getPixmap(":/Images/health.png", 22.0, 22.0);
 }
 
 void Health::initializeSounds() {
@@ -24,6 +30,15 @@ std::unique_ptr<GameObject> Health::clone() const {
   health->m_destructionSoundInfo = m_destructionSoundInfo;
   health->m_objectTypes = m_objectTypes;
   return health;
+}
+
+namespace {
+struct PixmapRegistrar {
+    PixmapRegistrar() {
+        PixmapRegistry::instance().add(&Health::registerPixmaps);
+    }
+};
+static PixmapRegistrar _health_pixmap_registrar;
 }
 
 } // namespace Collectables

--- a/GameObjects/Collectables/Health.h
+++ b/GameObjects/Collectables/Health.h
@@ -9,6 +9,7 @@ namespace Collectables {
 class Health : public Collectable {
 public:
   Health(const Position &position);
+  static void registerPixmaps();
 
   // GameObject interface
 protected:

--- a/GameObjects/Projectiles/PlayerLaserProjectile.cpp
+++ b/GameObjects/Projectiles/PlayerLaserProjectile.cpp
@@ -1,6 +1,8 @@
 #include "PlayerLaserProjectile.h"
 #include "Game/Audio/SoundInfo.h"
 #include <QPen>
+#include "Graphics/PixmapLibrary.h"
+#include "Graphics/PixmapRegistry.h"
 
 namespace GameObjects {
 namespace Projectiles {
@@ -9,6 +11,10 @@ PlayerLaserProjectile::PlayerLaserProjectile(
     : Projectile(damage, properties) {
   m_pixmapData.pixmapResourcePath = ":/Images/player_laser_projectile.png";
   m_pixmapData.pixmapScale = QPointF(30, 30);
+}
+
+void PlayerLaserProjectile::registerPixmaps() {
+    Graphics::PixmapLibrary::getPixmap(":/Images/player_laser_projectile.png", 30, 30);
 }
 
 std::unique_ptr<Projectile> PlayerLaserProjectile::clone() const {
@@ -28,6 +34,15 @@ void PlayerLaserProjectile::initializeObjectType() {
 void PlayerLaserProjectile::initializeSounds() {
   m_spawnSoundInfo =
       Game::Audio::SoundInfo({m_soundEnabled, Game::Audio::SoundEffect::LASER});
+}
+
+namespace {
+struct PixmapRegistrar {
+    PixmapRegistrar() {
+        PixmapRegistry::instance().add(&PlayerLaserProjectile::registerPixmaps);
+    }
+};
+static PixmapRegistrar _playerlaserprojectile_pixmap_registrar;
 }
 
 } // namespace Projectiles

--- a/GameObjects/Projectiles/PlayerLaserProjectile.h
+++ b/GameObjects/Projectiles/PlayerLaserProjectile.h
@@ -10,6 +10,7 @@ public:
   PlayerLaserProjectile(int damage = 1,
                         std::unordered_set<ProjectileProperty> properties = {});
   std::unique_ptr<Projectile> clone() const override;
+  static void registerPixmaps();
 
   // GameObject interface
 public:

--- a/GameObjects/Projectiles/Vortex.cpp
+++ b/GameObjects/Projectiles/Vortex.cpp
@@ -1,4 +1,6 @@
 #include "Vortex.h"
+#include "Graphics/PixmapLibrary.h"
+#include "Graphics/PixmapRegistry.h"
 
 namespace GameObjects {
 namespace Projectiles {
@@ -11,6 +13,12 @@ Vortex::Vortex() : m_timeToLiveSeconds(5.0f), m_timeSinceSpawnSeconds(0.0f) {
   m_pixmapData.onHitPixmapResourcePath = ":/Images/black_hole.png";
   m_pixmapData.hudPixmapResourcePath = ":/Images/black_hole_hud.png";
   m_pixmapData.pixmapScale = QPointF(25, 25);
+}
+
+void Vortex::registerPixmaps() {
+    Graphics::PixmapLibrary::getPixmap(":/Images/black_orb.png", 25, 25);
+    Graphics::PixmapLibrary::getPixmap(":/Images/black_hole.png", 25, 25);
+    Graphics::PixmapLibrary::getPixmap(":/Images/black_hole_hud.png", 25, 25);
 }
 
 void Vortex::update(const UpdateContext &context) {
@@ -43,6 +51,15 @@ std::unique_ptr<GameObject> Vortex::clone() const {
   projectile->setPixmapData(m_pixmapData);
   projectile->setMovementStrategy(movementStrategy());
   return projectile;
+}
+
+namespace {
+struct PixmapRegistrar {
+    PixmapRegistrar() {
+        PixmapRegistry::instance().add(&Vortex::registerPixmaps);
+    }
+};
+static PixmapRegistrar _vortex_pixmap_registrar;
 }
 
 } // namespace Projectiles

--- a/GameObjects/Projectiles/Vortex.h
+++ b/GameObjects/Projectiles/Vortex.h
@@ -9,6 +9,7 @@ namespace Projectiles {
 class Vortex : public Projectile {
 public:
   Vortex();
+  static void registerPixmaps();
 
 private:
   float m_timeToLiveSeconds;

--- a/GameObjects/Projectiles/WaveOfDestruction.cpp
+++ b/GameObjects/Projectiles/WaveOfDestruction.cpp
@@ -1,4 +1,6 @@
 #include "WaveOfDestruction.h"
+#include "Graphics/PixmapLibrary.h"
+#include "Graphics/PixmapRegistry.h"
 
 namespace GameObjects {
 namespace Projectiles {
@@ -9,6 +11,11 @@ WaveOfDestruction::WaveOfDestruction() {
   m_pixmapData.hudPixmapResourcePath = ":/Images/wave_of_destruction_hud.png";
   m_pixmapData.pixmapScale = QPointF(250, 20);
   m_pixmapData.keepAspectRatio = false;
+}
+
+void WaveOfDestruction::registerPixmaps() {
+    Graphics::PixmapLibrary::getPixmap(":/Images/wave.png", 250, 20, false);
+    Graphics::PixmapLibrary::getPixmap(":/Images/wave_of_destruction_hud.png", 250, 20, false);
 }
 
 bool WaveOfDestruction::shouldBeDeleted() {
@@ -28,6 +35,15 @@ std::unique_ptr<GameObject> WaveOfDestruction::clone() const {
   projectile->setPixmapData(m_pixmapData);
   projectile->setMovementStrategy(movementStrategy());
   return projectile;
+}
+
+namespace {
+struct PixmapRegistrar {
+    PixmapRegistrar() {
+        PixmapRegistry::instance().add(&WaveOfDestruction::registerPixmaps);
+    }
+};
+static PixmapRegistrar _waveofdestruction_pixmap_registrar;
 }
 
 } // namespace Projectiles

--- a/GameObjects/Projectiles/WaveOfDestruction.h
+++ b/GameObjects/Projectiles/WaveOfDestruction.h
@@ -9,6 +9,7 @@ namespace Projectiles {
 class WaveOfDestruction : public Projectile {
 public:
   WaveOfDestruction();
+  static void registerPixmaps();
 
   // GameObject interface
 public:

--- a/GameObjects/Ships/EnemyShip.cpp
+++ b/GameObjects/Ships/EnemyShip.cpp
@@ -3,6 +3,8 @@
 #include "GameObjects/Collectables/Health.h"
 #include "GameObjects/Collectables/Stellar.h"
 #include "Utils/Utils.h"
+#include "Graphics/PixmapLibrary.h"
+#include "Graphics/PixmapRegistry.h"
 #include <QColor>
 #include <QGraphicsScene>
 #include <QPen>
@@ -19,6 +21,11 @@ EnemyShip::EnemyShip(const std::uint32_t maxHp, const Position &position)
   m_pixmapData.onHitPixmapResourcePath = ":/Images/alien_on_hit.png";
   m_pixmapData.pixmapScale = QPointF(50.0, 50.0);
   m_magneticTargets = {ObjectType::PROJECTILE};
+}
+
+void EnemyShip::registerPixmaps() {
+    Graphics::PixmapLibrary::getPixmap(":/Images/alien.png", 50.0, 50.0);
+    Graphics::PixmapLibrary::getPixmap(":/Images/alien_on_hit.png", 50.0, 50.0);
 }
 
 void EnemyShip::initializeObjectType() {
@@ -138,6 +145,15 @@ void EnemyShip::collideWithProjectile(Projectiles::Projectile &projectile) {
 void EnemyShip::collideWithEnemyShip(EnemyShip &enemyShip) {
   Q_UNUSED(enemyShip);
   takeDamage(0);
+}
+
+namespace {
+struct PixmapRegistrar {
+    PixmapRegistrar() {
+        PixmapRegistry::instance().add(&EnemyShip::registerPixmaps);
+    }
+};
+static PixmapRegistrar _enemyship_pixmap_registrar;
 }
 
 } // namespace Ships

--- a/GameObjects/Ships/EnemyShip.h
+++ b/GameObjects/Ships/EnemyShip.h
@@ -10,6 +10,7 @@ class EnemyShip : public ShipWithHealthBar {
   Q_OBJECT
 public:
   EnemyShip(const std::uint32_t maxHp, const Position &position);
+  static void registerPixmaps();
   void collideWith(GameObject &other) override;
   void collideWithProjectile(Projectiles::Projectile &projectile) override;
   void collideWithEnemyShip(EnemyShip &enemyShip) override;

--- a/GameObjects/Ships/PlayerShip.cpp
+++ b/GameObjects/Ships/PlayerShip.cpp
@@ -2,6 +2,8 @@
 #include "GameObjects/Collectables/Collectable.h"
 #include "GameObjects/Projectiles/Projectile.h"
 #include <QPen>
+#include "Graphics/PixmapLibrary.h"
+#include "Graphics/PixmapRegistry.h"
 
 namespace GameObjects {
 namespace Ships {
@@ -10,6 +12,10 @@ PlayerShip::PlayerShip(const float speed, const Position &position)
   m_magnetism = {true, true, 100.0f, 100.0f};
   m_pixmapData.pixmapResourcePath = ":/Images/player_ship.png";
   m_pixmapData.pixmapScale = QPointF(50.0, 50.0);
+}
+
+void PlayerShip::registerPixmaps() {
+    Graphics::PixmapLibrary::getPixmap(":/Images/player_ship.png", 50.0, 50.0);
 }
 
 void PlayerShip::update(const UpdateContext &context) {
@@ -180,6 +186,15 @@ void PlayerShip::disableMovement() {
   m_currentSpeedX = 0;
   m_currentSpeedY = 0;
   m_acceleration = 0;
+}
+
+namespace {
+struct PixmapRegistrar {
+    PixmapRegistrar() {
+        PixmapRegistry::instance().add(&PlayerShip::registerPixmaps);
+    }
+};
+static PixmapRegistrar _playership_pixmap_registrar;
 }
 } // namespace Ships
 

--- a/GameObjects/Ships/PlayerShip.h
+++ b/GameObjects/Ships/PlayerShip.h
@@ -9,6 +9,7 @@ class PlayerShip : public Ship {
   Q_OBJECT
 public:
   PlayerShip(const float speed, const Position &position);
+  static void registerPixmaps();
 
   // GameObject interface
 public:


### PR DESCRIPTION
## Summary
- add static `registerPixmaps()` method to several game object classes
- preload each object's pixmap via `PixmapRegistry`
- automatically register pixmaps on startup

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_685c844b1dc4832395ae20545d39540c