### PR TITLE
Fix OpenGL setup

### DIFF
--- a/Game/Core/GameRunnerView.cpp
+++ b/Game/Core/GameRunnerView.cpp
@@ -123,8 +123,6 @@ void GameRunnerView::setupView() {
   // format.setSwapBehavior(QSurfaceFormat::TripleBuffer);
   format.setSwapInterval(0);
   format.setRenderableType(QSurfaceFormat::RenderableType::OpenGL);
-  QOpenGLWidget *glWidget = new QOpenGLWidget;
-  glWidget->setFormat(format);
   QSurfaceFormat::setDefaultFormat(format);
 }
 


### PR DESCRIPTION
## Summary
- remove allocation of `QOpenGLWidget` during view setup

## Testing
- `scripts/setup_and_build_linux.sh --help` *(fails: command not found or missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68644782ec448323a51e005c064454fd