### PR TITLE
Clean up GameRunnerView resources

### DIFF
--- a/Game/Core/GameRunnerView.cpp
+++ b/Game/Core/GameRunnerView.cpp
@@ -116,6 +116,17 @@ GameRunnerView::~GameRunnerView() {
   delete m_lineProgram;
   if (m_gameHUD)
     delete m_gameHUD;
+  delete m_fpsCounter;
+  delete m_gameObjectCounter;
+  delete m_stellarTokens;
+  delete m_playerHp;
+  delete m_levelEndedInfo;
+
+  m_vao.destroy();
+  m_debugVao.destroy();
+  m_vbo.destroy();
+  if (m_texture != 0)
+    glDeleteTextures(1, &m_texture);
 }
 
 void GameRunnerView::setupView() {


### PR DESCRIPTION
## Summary
- free HUD counters in GameRunnerView destructor
- destroy OpenGL buffers and textures when finishing

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt6")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_6864478398fc8323ad1c12a975d56c6d