### PR TITLE
Destroy GL objects when clearing EffectManager

### DIFF
--- a/Graphics/Effects/EffectManager.cpp
+++ b/Graphics/Effects/EffectManager.cpp
@@ -109,6 +109,12 @@ void EffectManager::spawnDestructionEffect(const QVector2D &pos, float lifeSpan,
 }
 
 void EffectManager::clear() {
+  if (m_glFuncs) {
+    for (auto &effect : m_effects)
+      effect->destroyGL(m_glFuncs);
+    for (auto &effect : m_pendingInit)
+      effect->destroyGL(m_glFuncs);
+  }
   m_effects.clear();
   m_pendingInit.clear();
 }


### PR DESCRIPTION
## Summary
- free GPU resources for ParticleSystem objects when calling `EffectManager::clear`

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6Config.cmake)*
- `ctest --test-dir build` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6864478626f48323ac9c35f2ecdfd0f7