### PR TITLE
Add ParticleSystem destructor and GL pointer

### DIFF
--- a/Graphics/Effects/ParticleSystem.cpp
+++ b/Graphics/Effects/ParticleSystem.cpp
@@ -5,9 +5,18 @@ namespace Graphics {
 namespace Effects {
 
 ParticleSystem::ParticleSystem(int maxParticles)
-    : m_maxParticles(maxParticles), m_vao(0), m_vbo(0) {}
+    : m_maxParticles(maxParticles), m_vao(0), m_vbo(0) {
+  m_particles.reserve(maxParticles);
+  m_vertexData.reserve(maxParticles * 6);
+}
+
+ParticleSystem::~ParticleSystem() {
+  if ((m_vao != 0 || m_vbo != 0) && m_glFuncs)
+    destroyGL(m_glFuncs);
+}
 
 void ParticleSystem::initializeGL(QOpenGLFunctions_3_3_Core *glFuncs) {
+  m_glFuncs = glFuncs;
   glFuncs->glGenVertexArrays(1, &m_vao);
   glFuncs->glGenBuffers(1, &m_vbo);
 
@@ -28,12 +37,14 @@ void ParticleSystem::initializeGL(QOpenGLFunctions_3_3_Core *glFuncs) {
 }
 
 void ParticleSystem::destroyGL(QOpenGLFunctions_3_3_Core *glFuncs) {
+  m_glFuncs = glFuncs;
   if (m_vao)
     glFuncs->glDeleteVertexArrays(1, &m_vao);
   if (m_vbo)
     glFuncs->glDeleteBuffers(1, &m_vbo);
   m_vao = 0;
   m_vbo = 0;
+  m_glFuncs = nullptr;
 }
 
 void ParticleSystem::uploadToGPU(QOpenGLFunctions_3_3_Core *glFuncs) {
@@ -59,6 +70,7 @@ void ParticleSystem::uploadToGPU(QOpenGLFunctions_3_3_Core *glFuncs) {
 }
 
 void ParticleSystem::render(QOpenGLFunctions_3_3_Core *glFuncs) {
+  m_glFuncs = glFuncs;
   glFuncs->glEnable(GL_PROGRAM_POINT_SIZE);
   glFuncs->glEnable(GL_BLEND);
   glFuncs->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/Graphics/Effects/ParticleSystem.h
+++ b/Graphics/Effects/ParticleSystem.h
@@ -24,7 +24,7 @@ public:
   void initializeGL(QOpenGLFunctions_3_3_Core *glFuncs);
   void destroyGL(QOpenGLFunctions_3_3_Core *glFuncs);
 
-  ~ParticleSystem() = default;
+  ~ParticleSystem();
 
 private:
   std::vector<Particle> m_particles;
@@ -34,6 +34,7 @@ private:
   GLuint m_vbo = 0;
   GLuint m_vao = 0;
   int m_maxParticles = 0;
+  QOpenGLFunctions_3_3_Core *m_glFuncs = nullptr;
 
   // Internal buffer for sending data to GPU
   std::vector<float> m_vertexData; // [x, y, r, g, b, a]


### PR DESCRIPTION
## Summary
- track the last used `QOpenGLFunctions_3_3_Core` in `ParticleSystem`
- reserve particle storage during construction
- clean up GL resources from the destructor

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6864478627c88323994d52fa0bce2368