### PR TITLE
Implement TextureRegistry cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ set(SOURCES
     Graphics/EnergyBar.cpp
     Graphics/HealthBar.cpp
     Graphics/ProgressBar.cpp
+    Graphics/TextureRegistry.cpp
     Main/main.cpp
     UI/FPSCounter.cpp
     UI/GameObjectCounter.cpp

--- a/Graphics/TextureRegistry.cpp
+++ b/Graphics/TextureRegistry.cpp
@@ -1,0 +1,22 @@
+#include "TextureRegistry.h"
+
+namespace Graphics {
+
+TextureRegistry::~TextureRegistry() {
+  clear();
+}
+
+void TextureRegistry::clear() {
+  if (m_gl) {
+    for (auto it = m_textures.begin(); it != m_textures.end(); ++it) {
+      if (it.value().handle)
+        m_gl->glDeleteTextures(1, &it.value().handle);
+    }
+    if (m_placeholder.handle)
+      m_gl->glDeleteTextures(1, &m_placeholder.handle);
+  }
+  m_textures.clear();
+  m_placeholder = TextureInfo{0, 0, 0};
+}
+
+} // namespace Graphics

--- a/Graphics/TextureRegistry.h
+++ b/Graphics/TextureRegistry.h
@@ -23,6 +23,11 @@ public:
     return reg;
   }
 
+  ~TextureRegistry();
+
+  // Release all loaded textures. Instance remains usable after calling.
+  void clear();
+
   void setGlContext(QOpenGLFunctions_3_3_Core *gl) {
     m_gl = gl;
     createPlaceholder(); // ensure placeholder is created once gl is set!


### PR DESCRIPTION
## Summary
- create `TextureRegistry` destructor and `clear()` method
- release textures when clearing
- include new implementation file in build

## Testing
- `cmake -B build` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_6865b927461c83238f26bf8b1adf3ec4